### PR TITLE
Dev

### DIFF
--- a/IoTHubClientGenerator/CreateDeviceClientMethod.cs
+++ b/IoTHubClientGenerator/CreateDeviceClientMethod.cs
@@ -21,13 +21,7 @@ namespace IoTHubClientGenerator
                         var attAssignment = $"the{argument.NameEquals}";
                         parameterNameList.Add(argument.NameEquals?.ToString().TrimEnd('=', ' ', '\t').Trim());
                         var attExpression = argument.Expression.ToString();
-                        if (attExpression.StartsWith("\"%") && attExpression.EndsWith("%\""))
-                        {
-                            attExpression =
-                                $"System.Environment.GetEnvironmentVariable(\"{attExpression.TrimStart('%', '"').TrimEnd('%', '"')}\")";
-                        }
-
-                        AppendLine($"var {attAssignment}{attExpression};");
+                        CreateVariableAssignmentLineFromAttributeParameter(attAssignment, attExpression);
                     }
                 }
                 else

--- a/IoTHubClientGenerator/CreateDeviceClientMethodUsingDps.cs
+++ b/IoTHubClientGenerator/CreateDeviceClientMethodUsingDps.cs
@@ -21,13 +21,7 @@ namespace IoTHubClientGenerator
                         {
                             var attAssignment = $"the{argument.NameEquals}";
                             var attExpression = argument.Expression.ToString();
-                            if (attExpression.StartsWith("\"%") && attExpression.EndsWith("%\""))
-                            {
-                                attExpression =
-                                    $"System.Environment.GetEnvironmentVariable(\"{attExpression.TrimStart('%', '"').TrimEnd('%', '"')}\")";
-                            }
-
-                            AppendLine($"var {attAssignment}{attExpression};");
+                            CreateVariableAssignmentLineFromAttributeParameter(attAssignment, attExpression);
                         }
                     }
                     else

--- a/IoTHubClientGenerator/CreateDpsSymmetricKey.cs
+++ b/IoTHubClientGenerator/CreateDpsSymmetricKey.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using IoTHubClientGeneratorSDK;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace IoTHubClientGenerator
@@ -7,7 +8,15 @@ namespace IoTHubClientGenerator
     {
         private Action CreateDpsSymmetricKey(AttributeSyntax attributeSyntax)
         {
+            var dpsEnrollmentType =
+                GetAttributePropertyValue(attributeSyntax, nameof(DpsDeviceAttribute.EnrollmentType));
+            if (dpsEnrollmentType == nameof(DPSEnrollmentType) + "." + nameof(DPSEnrollmentType.Group))
+            {
+                AppendLine("thePrimarySymmetricKey = ComputeDerivedSymmetricKey(thePrimarySymmetricKey, theId);");
+            }
+            
             AppendLine("using var security = new SecurityProviderSymmetricKey(theId, thePrimarySymmetricKey, null);");
+            
             CreateProvisioningDeviceClient(attributeSyntax);
             AppendLine("IAuthenticationMethod auth = new DeviceAuthenticationWithRegistrySymmetricKey(result.DeviceId,security.GetPrimaryKey());");
 
@@ -16,9 +25,9 @@ namespace IoTHubClientGenerator
                 AppendLine("private static string ComputeDerivedSymmetricKey(string enrollmentKey, string deviceId)");
                 using (Block())
                 {
-                    using (If("string.IsNullOrWhiteSpace(enrollmentKey)"))
+                    using (If("string.IsNullOrWhiteSpace(deviceId)"))
                     {
-                        AppendLine("return enrollmentKey;");
+                        AppendLine("return enrollmentKey; //individual enrollment type"); 
                     }
                     AppendLine("using var hmac = new System.Security.Cryptography.HMACSHA256(System.Convert.FromBase64String(enrollmentKey));");
                     AppendLine("return Convert.ToBase64String(hmac.ComputeHash(System.Text.Encoding.UTF8.GetBytes(deviceId)));");

--- a/IoTHubClientGenerator/Generator.cs
+++ b/IoTHubClientGenerator/Generator.cs
@@ -137,9 +137,6 @@ namespace IoTHubClientGenerator
                 var properties = new List<string>
                 {
                     nameof(DpsDeviceAttribute.DPSIdScope),
-                    nameof(DpsDeviceAttribute.Id),
-                    nameof(DpsDeviceAttribute.EnrollmentGroupId),
-                    nameof(DpsDeviceAttribute.EnrollmentType),
                     nameof(DpsDeviceAttribute.DPSTransportType),
                 };
                 var attributeName = deviceAttributesNodes.First().Name.ToString();
@@ -147,6 +144,7 @@ namespace IoTHubClientGenerator
                 {
                     case { } attName when attName == nameof(DpsSymmetricKeyDeviceAttribute).AttName():
                         properties.Add(nameof(DpsSymmetricKeyDeviceAttribute.PrimarySymmetricKey));
+                        properties.Add(nameof(DpsDeviceAttribute.EnrollmentGroupId));
                         break;
                     case { } attName when attName == nameof(DpsX509CertificateDeviceAttribute).AttName():
                         properties.Add(nameof(DpsX509CertificateDeviceAttribute.CertificatePath));

--- a/IoTHubClientGenerator/IoTHubPartialClassBuilder.cs
+++ b/IoTHubClientGenerator/IoTHubPartialClassBuilder.cs
@@ -116,5 +116,22 @@ namespace IoTHubClientGenerator
                     CreateDesiredUpdateMethod();
             }
         }
+
+        //if the property value is wrap with %, we take the value from environment variable
+        //if the property value is wrap with [], we take the value from a variable name
+        //otherwise the property value is the value
+        private void CreateVariableAssignmentLineFromAttributeParameter(string attAssignment, string attExpression)
+        {
+            if (attExpression.StartsWith("\"%") && attExpression.EndsWith("%\""))
+            {
+                attExpression =
+                    $"System.Environment.GetEnvironmentVariable(\"{attExpression.TrimStart('%', '"').TrimEnd('%', '"')}\")";
+            }
+            else if (attExpression.StartsWith("\"[") && attExpression.EndsWith("]\""))
+            {
+                attExpression = attExpression.TrimStart('[', '"').TrimEnd(']', '"');
+            }
+            AppendLine($"var {attAssignment}{attExpression};");
+        }
     }
 }

--- a/IoTHubClientGeneratorTest/TestDPSSymmetricKeyAttributes.cs
+++ b/IoTHubClientGeneratorTest/TestDPSSymmetricKeyAttributes.cs
@@ -33,7 +33,7 @@ namespace TestDPSSymmetricKey
     partial class MyIoTHubClient
     {
         [DpsSymmetricKeyDevice(DPSIdScope=""%DpsScopeId%"", Id=""1"", EnrollmentGroupId=""GroupId"", 
-            EnrollmentType=DPSEnrollmentType.Individual, DPSTransportType=TransportType.Mqtt,
+            EnrollmentType=DPSEnrollmentType.Group, DPSTransportType=TransportType.Mqtt,
             PrimarySymmetricKey=""%PrimaryDPSKey%"")]
         private DeviceClient MyClient {get;set;}
 

--- a/IoTHubClientGeneratorTest/TestDeviceAttribute.cs
+++ b/IoTHubClientGeneratorTest/TestDeviceAttribute.cs
@@ -33,6 +33,24 @@ namespace TestConnectionString
     }
 }";
         
+        [TestCase("TestConnectionStringFromLocalVariable")] 
+        public static string TestConnectionStringFromLocalVariable => 
+            @"
+using IoTHubClientGeneratorSDK;
+using Microsoft.Azure.Devices.Client;
+
+namespace TestConnectionStringFromLocalVariable
+{
+    [IoTHub()]
+    partial class MyIoTHubClient
+    {
+        private static string PrimaryConnectionString = ""HostName=HomeAutomationHub.azure-devices.net;SharedAccessKeyName=device;SharedAccessKey=ROQYwme5GAWZxKdI5rIjLsimSMTfltIdLm/Cki3qfBq="";
+
+        [Device(ConnectionString=""[PrimaryConnectionString]"")]
+        private DeviceClient MyClient {get;set;}
+    }
+}";
+        
         [TestCase("TestConnectionStringEnv")] 
         public static string TestConnectionStringEnv => 
 @"

--- a/IoTHubClientGeneratorTest/TestRunner.TestCase.ForScenario.TestDPSSymmetricKey.approved.txt
+++ b/IoTHubClientGeneratorTest/TestRunner.TestCase.ForScenario.TestDPSSymmetricKey.approved.txt
@@ -64,9 +64,9 @@ namespace TestDPSSymmetricKey
 
         private static string ComputeDerivedSymmetricKey(string enrollmentKey, string deviceId)
         {
-            if (string.IsNullOrWhiteSpace(enrollmentKey))
+            if (string.IsNullOrWhiteSpace(deviceId))
             {
-                return enrollmentKey;
+                return enrollmentKey; //individual enrollment type
             }
 
             using var hmac = new System.Security.Cryptography.HMACSHA256(System.Convert.FromBase64String(enrollmentKey));

--- a/IoTHubClientGeneratorTest/TestRunner.TestCase.ForScenario.TestDPSSymmetricKeyWithClientOptions.approved.txt
+++ b/IoTHubClientGeneratorTest/TestRunner.TestCase.ForScenario.TestDPSSymmetricKeyWithClientOptions.approved.txt
@@ -67,9 +67,9 @@ namespace TestDPSSymmetricKey
 
         private static string ComputeDerivedSymmetricKey(string enrollmentKey, string deviceId)
         {
-            if (string.IsNullOrWhiteSpace(enrollmentKey))
+            if (string.IsNullOrWhiteSpace(deviceId))
             {
-                return enrollmentKey;
+                return enrollmentKey; //individual enrollment type
             }
 
             using var hmac = new System.Security.Cryptography.HMACSHA256(System.Convert.FromBase64String(enrollmentKey));

--- a/IoTHubClientGeneratorTest/TestRunner.TestCase.ForScenario.TestDPSSymmetricKeyWithTransportSettings.approved.txt
+++ b/IoTHubClientGeneratorTest/TestRunner.TestCase.ForScenario.TestDPSSymmetricKeyWithTransportSettings.approved.txt
@@ -11,7 +11,7 @@ namespace TestDPSSymmetricKey
     partial class MyIoTHubClient
     {
         [DpsSymmetricKeyDevice(DPSIdScope="%DpsScopeId%", Id="1", EnrollmentGroupId="GroupId", 
-            EnrollmentType=DPSEnrollmentType.Individual, DPSTransportType=TransportType.Mqtt,
+            EnrollmentType=DPSEnrollmentType.Group, DPSTransportType=TransportType.Mqtt,
             PrimarySymmetricKey="%PrimaryDPSKey%")]
         private DeviceClient MyClient {get;set;}
 
@@ -58,10 +58,11 @@ namespace TestDPSSymmetricKey
             var theDPSIdScope = System.Environment.GetEnvironmentVariable("DpsScopeId");
             var theId = "1";
             var theEnrollmentGroupId = "GroupId";
-            var theEnrollmentType = DPSEnrollmentType.Individual;
+            var theEnrollmentType = DPSEnrollmentType.Group;
             var theDPSTransportType = TransportType.Mqtt;
             var thePrimarySymmetricKey = System.Environment.GetEnvironmentVariable("PrimaryDPSKey");
             ITransportSettings[] transportSettings = new[]{AmqpTransportSettings, MqttTransportSetting};
+            thePrimarySymmetricKey = ComputeDerivedSymmetricKey(thePrimarySymmetricKey, theId);
             using var security = new SecurityProviderSymmetricKey(theId, thePrimarySymmetricKey, null);
             using var transport = new ProvisioningTransportHandlerMqtt();
             var theGlobalDeviceEndpoint = "global.azure-devices-provisioning.net";
@@ -79,9 +80,9 @@ namespace TestDPSSymmetricKey
 
         private static string ComputeDerivedSymmetricKey(string enrollmentKey, string deviceId)
         {
-            if (string.IsNullOrWhiteSpace(enrollmentKey))
+            if (string.IsNullOrWhiteSpace(deviceId))
             {
-                return enrollmentKey;
+                return enrollmentKey; //individual enrollment type
             }
 
             using var hmac = new System.Security.Cryptography.HMACSHA256(System.Convert.FromBase64String(enrollmentKey));

--- a/IoTHubClientGeneratorTest/TestRunner.TestCase.ForScenario.TestDPSSymmetricKeyWithTransportSettingsAndClientOptions.approved.txt
+++ b/IoTHubClientGeneratorTest/TestRunner.TestCase.ForScenario.TestDPSSymmetricKeyWithTransportSettingsAndClientOptions.approved.txt
@@ -82,9 +82,9 @@ namespace TestDPSSymmetricKey
 
         private static string ComputeDerivedSymmetricKey(string enrollmentKey, string deviceId)
         {
-            if (string.IsNullOrWhiteSpace(enrollmentKey))
+            if (string.IsNullOrWhiteSpace(deviceId))
             {
-                return enrollmentKey;
+                return enrollmentKey; //individual enrollment type
             }
 
             using var hmac = new System.Security.Cryptography.HMACSHA256(System.Convert.FromBase64String(enrollmentKey));

--- a/IoTHubClientGeneratorTest/TestRunner.TestCase.ForScenario.TestDPSSymmetricKeyWithTransportSettingsAndClientOptionsAndErrorHandling.approved.txt
+++ b/IoTHubClientGeneratorTest/TestRunner.TestCase.ForScenario.TestDPSSymmetricKeyWithTransportSettingsAndClientOptionsAndErrorHandling.approved.txt
@@ -101,9 +101,9 @@ namespace TestDPSSymmetricKey
 
         private static string ComputeDerivedSymmetricKey(string enrollmentKey, string deviceId)
         {
-            if (string.IsNullOrWhiteSpace(enrollmentKey))
+            if (string.IsNullOrWhiteSpace(deviceId))
             {
-                return enrollmentKey;
+                return enrollmentKey; //individual enrollment type
             }
 
             using var hmac = new System.Security.Cryptography.HMACSHA256(System.Convert.FromBase64String(enrollmentKey));

--- a/IoTHubClientGeneratorTest/TestRunner.TestCase.ForScenario.TestDpsAttributeMissingProperties.approved.txt
+++ b/IoTHubClientGeneratorTest/TestRunner.TestCase.ForScenario.TestDpsAttributeMissingProperties.approved.txt
@@ -1,4 +1,4 @@
-Xunit.Sdk.FalseException: Failed: [DpsSymmetricKeyDevice] must define these missing properties: EnrollmentGroupId EnrollmentType DPSTransportType PrimarySymmetricKey TransportType
+Xunit.Sdk.FalseException: Failed: [DpsSymmetricKeyDevice] must define these missing properties: DPSTransportType PrimarySymmetricKey EnrollmentGroupId TransportType
 Expected: False
 Actual:   True
    at Xunit.Assert.False(Nullable`1 condition, String userMessage) in C:\Dev\xunit\xunit\src\xunit.assert\Asserts\BooleanAsserts.cs:line 52


### PR DESCRIPTION
Fix DPS creation bug
Add [VarName] option to use variables in addition to environment variables and constant strings. 
Example:

private static string CSFromVar="fgserg3456tesrg";

[Device(ConnectionString="[CSFromVar]"]
DeviceClient DeviceClient {get;set;}